### PR TITLE
Add hyperlink for direct Mumble connection

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 					<div class="startcontent">
 						<h2>Mumbletreff.com</h2>
 						<h2>Ein Sprachchat für alle Themen!</h2>
-						<p>Rede mit uns auf voice.mumbletreff.com:10012 via Mumble.</p>
+						<p>Rede mit uns auf <a href="mumble://voice.mumbletreff.com:10012?title=Mumbletreff.com">voice.mumbletreff.com:10012</a> via Mumble.</p>
 						<img src="img/mumble.png"/>
 						<div class="button">
 							<a href="http://mumble.info" target="_blank">DOWNLOAD MUMBLE</a>
@@ -87,7 +87,7 @@
 <li>Finde uns in der offiziellen Serverliste in Deutschland unter dem Namen “Mumbletreff.com” Oder trage direkt die Zugangsdaten in deinen Mumble-Client ein:</p>
 <pre><code> Server: voice.mumbletreff.com
  Port: 10012</code></pre>
-Bei korrekt installiertem Mumble brauchst du nur hier zu klicken: Mumble-Link</li>
+Bei korrekt installiertem Mumble brauchst du nur hier zu klicken: <a href="mumble://voice.mumbletreff.com:10012?title=Mumbletreff.com">Mumble-Link</a></li>
 <li>Verbinde dich mit dem Server und ein Moderator wird sich in wenigen Minuten bei dir melden, um dich freizuschalten.</li>
 </ol>
 


### PR DESCRIPTION
This pull request adds back the hyperlinks from the original homepage. Users can click on the link and Mumble will auto connect to the server.